### PR TITLE
chore: zizmor trunk plugin and reusable workflows (INT-1582)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,33 +1,22 @@
 name: Lint
 
+# We ignore the dangerous-triggers warning because forked PRs
+# require repo secrets to run some of the defined checks,
+# and we protect against malicious actors by requiring approval
+# for all external contributors before workflows will run.
+on: pull_request_target # zizmor: ignore[dangerous-triggers]
+
 concurrency:
-  group: lint-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-on: pull_request_target
-
-permissions:
-  actions: read
-  checks: write
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Trunk Check
-        uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
-        env:
-          # NOTE: inject the GITHUB_TOKEN for the trunk managed tflint linter
-          # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  conventional-title:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: masterpointio/actions/.github/workflows/lint.yaml@7dad35e85d864ca5dda0971dfd3c940cc67ed380 #v0.3.0
+    permissions:
+      actions: read # for trunk-action
+      checks: write # for trunk-action
+      contents: read # for trunk-action + checkout
+      pull-requests: read # for action-semantic-pull-request

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -5,23 +5,21 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create Token for MasterpointBot App
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a #v2.1.0
-        id: generate-token
-        with:
-          app_id: ${{ secrets.MP_BOT_APP_ID }}
-          private_key: ${{ secrets.MP_BOT_APP_PRIVATE_KEY }}
-
-      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f #v4.1.3
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
-          release-type: terraform-module
+    uses: masterpointio/actions/.github/workflows/release-please.yaml@7dad35e85d864ca5dda0971dfd3c940cc67ed380 #v0.3.0
+    with:
+      release-type: terraform-module
+    secrets:
+      MP_BOT_APP_ID: ${{ secrets.MP_BOT_APP_ID }}
+      MP_BOT_APP_PRIVATE_KEY: ${{ secrets.MP_BOT_APP_PRIVATE_KEY }}
+    permissions:
+      contents: write # needed by release-please-action
+      pull-requests: write # needed by release-please-action
+      issues: write # needed by release-please-action

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,25 +4,30 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  # We ignore the dangerous-triggers warning because forked PRs
+  # require repo secrets to run some of the defined checks,
+  # and we protect against malicious actors by requiring approval
+  # for all external contributors before workflows will run.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
 
-permissions:
-  actions: read
-  checks: write
-  contents: read
-  id-token: write
-  pull-requests: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   tf-test:
-    name: 🧪 ${{ matrix.tf }} test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        tf: [tofu, terraform]
-    steps:
-      - uses: masterpointio/github-action-tf-test@c1e41998f67925ac3f34e0bbcfcaa4a44d1f0cd9 # v1.0.1
-        with:
-          tf_type: ${{ matrix.tf }}
-          aws_role_arn: ${{ vars.TF_TEST_AWS_ROLE_ARN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+    uses: masterpointio/actions/.github/workflows/tf-test.yaml@7dad35e85d864ca5dda0971dfd3c940cc67ed380 #v0.3.0
+    with:
+      aws_role_arn: ${{ vars.TF_TEST_AWS_ROLE_ARN }}
+    secrets:
+      SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}
+      SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
+      SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+    permissions:
+      actions: read # needed by github-action-tf-test
+      checks: write # needed by github-action-tf-test
+      contents: read # needed by github-action-tf-test
+      id-token: write # needed by github-action-tf-test
+      pull-requests: read # needed by github-action-tf-test

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -6,23 +6,19 @@ on:
     - cron: 0 8 1 * *
   workflow_dispatch: {}
 
-permissions: read-all
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   trunk-upgrade:
-    runs-on: ubuntu-latest
+    uses: masterpointio/actions/.github/workflows/trunk-upgrade.yaml@7dad35e85d864ca5dda0971dfd3c940cc67ed380 #v0.3.0
+    secrets:
+      MP_BOT_APP_ID: ${{ secrets.MP_BOT_APP_ID }}
+      MP_BOT_APP_PRIVATE_KEY: ${{ secrets.MP_BOT_APP_PRIVATE_KEY }}
+      MASTERPOINT_TEAM_PAT: ${{ secrets.MASTERPOINT_TEAM_PAT }}
     permissions:
-      # For trunk to create PRs
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Run Trunk Upgrade
-        uses: masterpointio/github-action-trunk-upgrade@a79fd65d524d92031fe167daee411d2f25d4a999 # v0.1.0
-        with:
-          app-id: ${{ secrets.MP_BOT_APP_ID }}
-          app-private-key: ${{ secrets.MP_BOT_APP_PRIVATE_KEY }}
-          github-token: ${{ secrets.MASTERPOINT_TEAM_PAT }}
-          reviewers: "@masterpointio/masterpoint-open-source"
+      contents: write # needed by github-action-trunk-upgrade
+      pull-requests: write # needed by github-action-trunk-upgrade

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,7 +7,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.6
+      ref: v1.10.1
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -29,6 +29,19 @@ lint:
     - tflint@0.61.0
     - trufflehog@3.94.1
     - yamllint@1.38.0
+    - zizmor@1.25.2
+  definitions:
+    - name: zizmor
+      environment:
+        # Optional token here so that it's not needed locally, but can be used
+        # when trunk is called from our lint workflow in GHA
+        - name: ZIZMOR_GITHUB_TOKEN
+          value: ${env.GITHUB_TOKEN}
+          optional: true
+      commands:
+        # Set to pedantic so that zizmor will run its stale-action-refs audit rule
+        - name: lint
+          run: zizmor --format=sarif --persona=pedantic ${target}
   ignore:
     - linters: [tofu]
       paths:


### PR DESCRIPTION
## what

- Refactor workflows to utilize reusable/centralized workflows in our actions repo
- Add the Zizmor plugin to trunk, for static analysis of our Github Actions

## why

- Align this repo with our centralized standard workflows
- Improve our security posture with zizmor and also set an example for clients

## references

- [INT-1582](https://www.notion.so/masterpoint/Roll-out-Zizmor-across-all-Masterpoint-OSS-repos-08a6992b18de4b9581bec3eb579715b1)